### PR TITLE
Add additional source/javadoc artifacts, support mvn pom with uploads

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,26 @@ allprojects{
     }
 }
 
+subprojects{
+    apply plugin: 'maven'
+    
+    //All projects should provide source code and javadoc, and upload these with any released artifacts
+    task sourcesJar(type: Jar, dependsOn: classes) {
+        classifier = 'sources'
+        from sourceSets.main.allSource
+    }
+    
+    task javadocJar(type: Jar, dependsOn: javadoc) {
+        classifier = 'javadoc'
+        from javadoc.destinationDir
+    }
+    
+    artifacts {
+        archives sourcesJar
+        archives javadocJar
+    }
+}
+
 task wrapper(type: Wrapper) {
     gradleVersion = "${gradleVersion}"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Application Versions
-coronaIdeVersion=0.1
+coronaIdeVersion=0.1.0-SNAPSHOT
 
 # Consumed Language/Build System Versions
 javaVersion=1.8


### PR DESCRIPTION
Add sources and javadoc jar build artifacts, and add these jars to the set of artifacts uploaded to any binary repositories. In addition, add the maven Gradle plugin, which will generate a pom.xml file which automated dependency management systems can use to resolve transitive dependency information