### PR TITLE
Application Representation and Service

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -11,3 +11,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Gradle build system setup
 - Basic documentation
 - Datastore APIs which allow storage and retrieval for data by modules
+- Application APIs which allow manipulation of IDE application instance data

--- a/corona-ide-core-api/src/main/java/com/coronaide/core/Application.java
+++ b/corona-ide-core-api/src/main/java/com/coronaide/core/Application.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) Oct 24, 2016 Corona IDE.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    romeara - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package com.coronaide.core;
+
+import java.nio.file.Path;
+
+/**
+ * Represents the Corona IDE application instance currently running
+ *
+ * @author romeara
+ * @since 0.1
+ */
+public interface Application {
+
+    /**
+     * @return The current running version of the application
+     * @since 0.1
+     */
+    Version getVersion();
+
+    /**
+     * @return Directory where all files managed by the Corona IDE application are located
+     * @since 0.1
+     */
+    Path getWorkingDirectory();
+
+}

--- a/corona-ide-core-api/src/main/java/com/coronaide/core/service/IApplicationService.java
+++ b/corona-ide-core-api/src/main/java/com/coronaide/core/service/IApplicationService.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) Oct 24, 2016 Corona IDE.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    romeara - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package com.coronaide.core.service;
+
+import com.coronaide.core.Application;
+
+/**
+ * Allows retrieval of Corona IDE application information
+ *
+ * @author romeara
+ * @since 0.1
+ */
+public interface IApplicationService {
+
+    /**
+     * @return A representation of basic data for the currently running application instance
+     * @since 0.1
+     */
+    Application get();
+}

--- a/corona-ide-core-api/src/main/java/com/coronaide/core/service/IDatastoreService.java
+++ b/corona-ide-core-api/src/main/java/com/coronaide/core/service/IDatastoreService.java
@@ -12,6 +12,7 @@ package com.coronaide.core.service;
 
 import java.util.Optional;
 
+import com.coronaide.core.Application;
 import com.coronaide.core.Datastore;
 import com.coronaide.core.Module;
 import com.coronaide.core.exception.DataStorageException;
@@ -29,6 +30,8 @@ public interface IDatastoreService {
      *
      * @param <T>
      *            The Java representation of the data to store
+     * @param application
+     *            Representation of the running Corona IDE application
      * @param module
      *            The module the data to store is associated with
      * @param datastore
@@ -40,13 +43,15 @@ public interface IDatastoreService {
      *             occurrence and indicates base program assumptions have been violated
      * @since 0.1
      */
-    <T> void storeApplicationData(Module module, Datastore<T> datastore, T data) throws DataStorageException;
+    <T> void store(Application application, Module module, Datastore<T> datastore, T data) throws DataStorageException;
 
     /**
      * Loads data from the application context for a specified module and data store
      *
      * @param <T>
      *            The Java representation of the data to store
+     * @param application
+     *            Representation of the running Corona IDE application
      * @param module
      *            The module the data to load is associated with
      * @param datastore
@@ -57,11 +62,13 @@ public interface IDatastoreService {
      *             occurrence and indicates base program assumptions have been violated
      * @since 0.1
      */
-    <T> Optional<T> loadApplicationData(Module module, Datastore<T> datastore) throws DataStorageException;
+    <T> Optional<T> load(Application application, Module module, Datastore<T> datastore) throws DataStorageException;
 
     /**
      * Clears all data associated with a module from the application context
      *
+     * @param application
+     *            Representation of the running Corona IDE application
      * @param module
      *            The module the data to clear is associated with
      * @throws DataStorageException
@@ -69,5 +76,5 @@ public interface IDatastoreService {
      *             occurrence and indicates base program assumptions have been violated
      * @since 0.1
      */
-    void clearApplicationData(Module module) throws DataStorageException;
+    void clear(Application application, Module module) throws DataStorageException;
 }

--- a/corona-ide-core/src/main/java/com/coronaide/core/impl/CoronaIdeApplication.java
+++ b/corona-ide-core/src/main/java/com/coronaide/core/impl/CoronaIdeApplication.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) Oct 24, 2016 Corona IDE.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    romeara - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package com.coronaide.core.impl;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+import com.coronaide.core.Application;
+import com.coronaide.core.Version;
+
+/**
+ * Represents the currently running Corona IDE application instance
+ *
+ * @author romeara
+ * @since 0.1
+ */
+@Immutable
+public class CoronaIdeApplication implements Application {
+
+    private static Version VERSION = new Version(0, 0, 1);
+
+    private Path workingDirectory;
+
+    /**
+     * @param workingDirectory
+     *            Directory all application generated/managed files should be placed within
+     * @since 0.1
+     */
+    public CoronaIdeApplication(Path workingDirectory) {
+        this.workingDirectory = Objects.requireNonNull(workingDirectory);
+    }
+
+    @Override
+    public Version getVersion() {
+        return VERSION;
+    }
+
+    @Override
+    public Path getWorkingDirectory() {
+        return workingDirectory;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getVersion(), getWorkingDirectory());
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        boolean result = false;
+
+        if (obj instanceof CoronaIdeApplication) {
+            CoronaIdeApplication compare = (CoronaIdeApplication) obj;
+
+            result = Objects.equals(compare.getVersion(), getVersion())
+                    && Objects.equals(compare.getWorkingDirectory(), getWorkingDirectory());
+        }
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder().append(getClass().getSimpleName()).append('{')
+                .append("version").append('=').append(getVersion()).append(',')
+                .append("workingDirectory").append('=').append(getWorkingDirectory())
+                .append('}').toString();
+    }
+}

--- a/corona-ide-core/src/main/java/com/coronaide/core/impl/package-info.java
+++ b/corona-ide-core/src/main/java/com/coronaide/core/impl/package-info.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) Oct 24, 2016 Corona IDE.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    romeara - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+/**
+ * Implementations of representations defined in the core APIs
+ *
+ * @author romeara
+ */
+@ParametersAreNonnullByDefault
+package com.coronaide.core.impl;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/corona-ide-core/src/main/java/com/coronaide/core/services/impl/ApplicationService.java
+++ b/corona-ide-core/src/main/java/com/coronaide/core/services/impl/ApplicationService.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) Oct 24, 2016 Corona IDE.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    romeara - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package com.coronaide.core.services.impl;
+
+import java.util.Objects;
+
+import com.coronaide.core.Application;
+import com.coronaide.core.impl.CoronaIdeApplication;
+import com.coronaide.core.internal.services.ICoreConfiguration;
+import com.coronaide.core.service.IApplicationService;
+
+/**
+ * Implementation of {@link IApplicationService}. Not intended for direct use by clients - use dependency injection to
+ * obtain an instance of {@link IApplicationService} instead
+ *
+ * @author romeara
+ * @since 0.1
+ */
+public class ApplicationService implements IApplicationService {
+
+    private final Application coronaIdeApplication;
+
+    /**
+     * Creates a new application service instance
+     *
+     * @param coreConfiguration
+     *            Configuration of the core Corona IDE application
+     * @since 0.1
+     */
+    public ApplicationService(ICoreConfiguration coreConfiguration) {
+        Objects.requireNonNull(coreConfiguration);
+
+        coronaIdeApplication = new CoronaIdeApplication(coreConfiguration.getApplicationWorkingDirectory());
+    }
+
+    @Override
+    public Application get() {
+        return coronaIdeApplication;
+    }
+
+}

--- a/corona-ide-core/src/main/java/com/coronaide/core/services/impl/DatastoreService.java
+++ b/corona-ide-core/src/main/java/com/coronaide/core/services/impl/DatastoreService.java
@@ -25,11 +25,11 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Objects;
 import java.util.Optional;
 
+import com.coronaide.core.Application;
 import com.coronaide.core.Datastore;
 import com.coronaide.core.Module;
 import com.coronaide.core.Version;
 import com.coronaide.core.exception.DataStorageException;
-import com.coronaide.core.internal.services.ICoreConfiguration;
 import com.coronaide.core.service.IDatastoreService;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
@@ -48,8 +48,6 @@ public class DatastoreService implements IDatastoreService {
 
     private final String VERSION_FILE = "versions.json";
 
-    private final ICoreConfiguration coreConfiguration;
-
     private final Gson gson;
 
     private final JsonParser jsonParser;
@@ -57,27 +55,23 @@ public class DatastoreService implements IDatastoreService {
     /**
      * Creates a new data store service instance
      *
-     * @param coreConfiguration
-     *            Configuration of the core Corona IDE application
      * @since 0.1
      */
-    public DatastoreService(ICoreConfiguration coreConfiguration) {
-        this.coreConfiguration = Objects.requireNonNull(coreConfiguration);
-
+    public DatastoreService() {
         gson = new Gson();
         jsonParser = new JsonParser();
     }
 
     @Override
-    public <T> void storeApplicationData(Module module, Datastore<T> datastore, T data) throws DataStorageException {
+    public <T> void store(Application application, Module module, Datastore<T> datastore, T data)
+            throws DataStorageException {
+        Objects.requireNonNull(application);
         Objects.requireNonNull(module);
         Objects.requireNonNull(datastore);
         Objects.requireNonNull(data);
 
-        Path applicationCoronaDir = coreConfiguration.getApplicationWorkingDirectory();
-
         try {
-            store(applicationCoronaDir, module, datastore, data);
+            store(application.getWorkingDirectory(), module, datastore, data);
         } catch (IOException e) {
             throw new DataStorageException(
                     "Error storing data store for module " + module.getId() + " (" + datastore.getKey() + ")", e);
@@ -85,14 +79,14 @@ public class DatastoreService implements IDatastoreService {
     }
 
     @Override
-    public <T> Optional<T> loadApplicationData(Module module, Datastore<T> datastore) throws DataStorageException {
+    public <T> Optional<T> load(Application application, Module module, Datastore<T> datastore)
+            throws DataStorageException {
+        Objects.requireNonNull(application);
         Objects.requireNonNull(module);
         Objects.requireNonNull(datastore);
 
-        Path applicationCoronaDir = coreConfiguration.getApplicationWorkingDirectory();
-
         try {
-            return load(applicationCoronaDir, module, datastore);
+            return load(application.getWorkingDirectory(), module, datastore);
         } catch (IOException e) {
             throw new DataStorageException(
                     "Error loading data store for module " + module.getId() + " (" + datastore.getKey() + ")", e);
@@ -100,13 +94,12 @@ public class DatastoreService implements IDatastoreService {
     }
 
     @Override
-    public void clearApplicationData(Module module) throws DataStorageException {
+    public void clear(Application application, Module module) throws DataStorageException {
+        Objects.requireNonNull(application);
         Objects.requireNonNull(module);
 
-        Path applicationCoronaDir = coreConfiguration.getApplicationWorkingDirectory();
-
         try {
-            clear(applicationCoronaDir, module);
+            clear(application.getWorkingDirectory(), module);
         } catch (IOException e) {
             throw new DataStorageException("Error clearing data store for module " + module.getId(), e);
         }

--- a/corona-ide-core/src/test/java/com/coronaide/core/impl/CoronaIdeApplicationTest.java
+++ b/corona-ide-core/src/test/java/com/coronaide/core/impl/CoronaIdeApplicationTest.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) Oct 25, 2016 Corona IDE.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    romeara - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package com.coronaide.core.impl;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Tests basic operations of the Corona IDE Application representation
+ *
+ * @author romeara
+ */
+public class CoronaIdeApplicationTest {
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void createNullPath() throws Exception {
+        new CoronaIdeApplication(null);
+    }
+
+    @Test
+    public void getTest() throws Exception {
+        Path workingDir = Paths.get("path");
+        CoronaIdeApplication result = new CoronaIdeApplication(workingDir);
+
+        Assert.assertNotNull(result.getVersion());
+        Assert.assertEquals(result.getWorkingDirectory().toString(), workingDir.toString());
+    }
+
+    @Test
+    public void hashCodeEqualWhenDataEqual() throws Exception {
+        CoronaIdeApplication app1 = new CoronaIdeApplication(Paths.get("path"));
+        CoronaIdeApplication app2 = new CoronaIdeApplication(Paths.get("path"));
+
+        Assert.assertEquals(app1.hashCode(), app2.hashCode());
+    }
+
+    @Test
+    public void equalsNull() throws Exception {
+        CoronaIdeApplication app = new CoronaIdeApplication(Paths.get("path"));
+
+        Assert.assertFalse(app.equals(null));
+    }
+
+    @Test
+    public void equalsDifferentClass() throws Exception {
+        CoronaIdeApplication app = new CoronaIdeApplication(Paths.get("path"));
+
+        Assert.assertFalse(app.equals("string"));
+    }
+
+    @Test
+    public void equalsSelf() throws Exception {
+        CoronaIdeApplication app = new CoronaIdeApplication(Paths.get("path"));
+
+        Assert.assertTrue(app.equals(app));
+    }
+
+    @Test
+    public void equalsDifferentData() throws Exception {
+        CoronaIdeApplication app1 = new CoronaIdeApplication(Paths.get("path1"));
+        CoronaIdeApplication app2 = new CoronaIdeApplication(Paths.get("path2"));
+
+        Assert.assertFalse(app1.equals(app2));
+    }
+
+    @Test
+    public void equalsSameData() throws Exception {
+        CoronaIdeApplication app1 = new CoronaIdeApplication(Paths.get("path"));
+        CoronaIdeApplication app2 = new CoronaIdeApplication(Paths.get("path"));
+
+        Assert.assertTrue(app1.equals(app2));
+    }
+
+}

--- a/corona-ide-core/src/test/java/com/coronaide/core/services/impl/ApplicationServiceErrorTest.java
+++ b/corona-ide-core/src/test/java/com/coronaide/core/services/impl/ApplicationServiceErrorTest.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) Oct 24, 2016 Corona IDE.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    romeara - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package com.coronaide.core.services.impl;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.coronaide.core.internal.services.ICoreConfiguration;
+
+/**
+ * Test basic error behavior of the application service
+ *
+ * @author romeara
+ */
+public class ApplicationServiceErrorTest {
+
+    @Mock
+    private ICoreConfiguration coreConfiguration;
+
+    @BeforeMethod
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void createNullCoreConfiguration() throws Exception {
+        new ApplicationService(null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void createNullApplicationDirectory() throws Exception {
+        Mockito.when(coreConfiguration.getApplicationWorkingDirectory()).thenReturn(null);
+
+        new ApplicationService(coreConfiguration);
+    }
+
+}

--- a/corona-ide-core/src/test/java/com/coronaide/core/services/impl/ApplicationServiceTest.java
+++ b/corona-ide-core/src/test/java/com/coronaide/core/services/impl/ApplicationServiceTest.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) Oct 24, 2016 Corona IDE.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    romeara - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package com.coronaide.core.services.impl;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.coronaide.core.Application;
+import com.coronaide.core.internal.services.ICoreConfiguration;
+import com.coronaide.core.service.IApplicationService;
+
+/**
+ * Tests basic operations of the application service
+ *
+ * @author romeara
+ */
+public class ApplicationServiceTest {
+
+    private final Path applicationDirectory = Paths.get("corona-ide");
+
+    @Mock
+    private ICoreConfiguration coreConfiguration;
+
+    private IApplicationService applicationService;
+
+    @BeforeMethod
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        Mockito.when(coreConfiguration.getApplicationWorkingDirectory()).thenReturn(applicationDirectory);
+
+        applicationService = new ApplicationService(coreConfiguration);
+    }
+
+    @Test
+    public void getApplication() throws Exception {
+        Application application = applicationService.get();
+
+        Assert.assertNotNull(application);
+        Assert.assertNotNull(application.getVersion());
+        Assert.assertEquals(application.getWorkingDirectory().toString(), applicationDirectory.toString());
+    }
+
+}

--- a/corona-ide-core/src/test/java/com/coronaide/core/services/impl/DatastoreServiceErrorTest.java
+++ b/corona-ide-core/src/test/java/com/coronaide/core/services/impl/DatastoreServiceErrorTest.java
@@ -10,16 +10,18 @@
  *******************************************************************************/
 package com.coronaide.core.services.impl;
 
+import java.nio.file.Paths;
+
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.coronaide.core.Application;
 import com.coronaide.core.Datastore;
 import com.coronaide.core.Module;
 import com.coronaide.core.Version;
-import com.coronaide.core.internal.services.ICoreConfiguration;
 import com.coronaide.core.service.IDatastoreService;
 
 /**
@@ -30,7 +32,7 @@ import com.coronaide.core.service.IDatastoreService;
 public class DatastoreServiceErrorTest {
 
     @Mock
-    private ICoreConfiguration coreConfiguration;
+    private Application application;
 
     @Mock
     private Module module;
@@ -43,40 +45,59 @@ public class DatastoreServiceErrorTest {
     @BeforeMethod
     public void setup() {
         MockitoAnnotations.initMocks(this);
+
         Mockito.when(module.getId()).thenReturn("com.coronaide.test");
         Mockito.when(module.getVersion()).thenReturn(new Version(1, 0, 0));
 
-        datastoreService = new DatastoreService(coreConfiguration);
+        Mockito.when(application.getVersion()).thenReturn(new Version(1, 0, 0));
+        Mockito.when(application.getWorkingDirectory()).thenReturn(Paths.get("app-dir"));
+
+        datastoreService = new DatastoreService();
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void storeApplicationNullApplication() throws Exception {
+        datastoreService.store(null, module, datastore, "data");
     }
 
     @Test(expectedExceptions = NullPointerException.class)
     public void storeApplicationDataNullModule() throws Exception {
-        datastoreService.storeApplicationData(null, datastore, "data");
+        datastoreService.store(application, null, datastore, "data");
     }
 
     @Test(expectedExceptions = NullPointerException.class)
     public void storeApplicationDataNullDatastore() throws Exception {
-        datastoreService.storeApplicationData(module, null, "data");
+        datastoreService.store(application, module, null, "data");
     }
 
     @Test(expectedExceptions = NullPointerException.class)
     public void storeApplicationDataNullData() throws Exception {
-        datastoreService.storeApplicationData(module, datastore, null);
+        datastoreService.store(application, module, datastore, null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void loadApplicationDataNullApplication() throws Exception {
+        datastoreService.load(null, module, datastore);
     }
 
     @Test(expectedExceptions = NullPointerException.class)
     public void loadApplicationDataNullModule() throws Exception {
-        datastoreService.loadApplicationData(null, datastore);
+        datastoreService.load(application, null, datastore);
     }
 
     @Test(expectedExceptions = NullPointerException.class)
     public void loadApplicationDataNullDatastore() throws Exception {
-        datastoreService.loadApplicationData(module, null);
+        datastoreService.load(application, module, null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void clearApplicationDataNullApplication() throws Exception {
+        datastoreService.clear(null, module);
     }
 
     @Test(expectedExceptions = NullPointerException.class)
     public void clearApplicationDataNullModule() throws Exception {
-        datastoreService.clearApplicationData(null);
+        datastoreService.clear(application, null);
     }
 
 }


### PR DESCRIPTION
Create a service to read a representation of the current application. This allows future property storage, and use of the application instead of internal configuration in locations where application information is needed.

Switch datastore service to use application representation. This additionally allows for more consistent method signatures for operations on application data and the upcoming workspace and project data operations
