### PR TITLE
Increase test coverage of basic bean operations

### DIFF
--- a/corona-ide-core-api/src/test/java/com/coronaide/core/VersionTest.java
+++ b/corona-ide-core-api/src/test/java/com/coronaide/core/VersionTest.java
@@ -59,7 +59,23 @@ public class VersionTest {
     }
 
     @Test
-    public void equalsDifferentData() throws Exception {
+    public void equalsDifferentMajor() throws Exception {
+        Version version1 = new Version(1, 2, 3);
+        Version version2 = new Version(4, 2, 3);
+
+        Assert.assertFalse(version1.equals(version2));
+    }
+
+    @Test
+    public void equalsDifferentMinor() throws Exception {
+        Version version1 = new Version(1, 2, 3);
+        Version version2 = new Version(1, 4, 3);
+
+        Assert.assertFalse(version1.equals(version2));
+    }
+
+    @Test
+    public void equalsDifferentMicro() throws Exception {
         Version version1 = new Version(1, 2, 3);
         Version version2 = new Version(1, 2, 4);
 
@@ -72,6 +88,13 @@ public class VersionTest {
         Version version2 = new Version(1, 2, 3);
 
         Assert.assertTrue(version1.equals(version2));
+    }
+
+    @Test
+    public void toStringTest() throws Exception {
+        Version version = new Version(1, 2, 3);
+
+        Assert.assertEquals(version.toString(), "1.2.3");
     }
 
 }

--- a/corona-ide-core-api/src/test/java/com/coronaide/core/exception/DataStorageExceptionTest.java
+++ b/corona-ide-core-api/src/test/java/com/coronaide/core/exception/DataStorageExceptionTest.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) Nov 1, 2016 Corona IDE.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    romeara - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package com.coronaide.core.exception;
+
+import java.io.IOException;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Test basic behavior of the {@link DataStorageException} class
+ *
+ * @author romeara
+ */
+public class DataStorageExceptionTest {
+
+    @Test
+    public void storedDataTest() throws Exception {
+        Exception cause = new IOException();
+        String message = "message";
+
+        DataStorageException result = new DataStorageException(message, cause);
+
+        Assert.assertEquals(result.getMessage(), message);
+        Assert.assertEquals(result.getCause(), cause);
+    }
+
+}

--- a/corona-ide-core/src/test/java/com/coronaide/core/impl/CoronaIdeApplicationTest.java
+++ b/corona-ide-core/src/test/java/com/coronaide/core/impl/CoronaIdeApplicationTest.java
@@ -82,4 +82,14 @@ public class CoronaIdeApplicationTest {
         Assert.assertTrue(app1.equals(app2));
     }
 
+    @Test
+    public void toStringTest() throws Exception {
+        CoronaIdeApplication app = new CoronaIdeApplication(Paths.get("path"));
+
+        String result = app.toString();
+
+        Assert.assertTrue(result.contains("version="));
+        Assert.assertTrue(result.contains("workingDirectory=path"));
+    }
+
 }


### PR DESCRIPTION
Test coverage reporting was being artificially decreased by lack of some basic bean tests. Add these tests to allow actual low coverage issues to be better identified