### PR TITLE
Add Ability to Perform Gradle Build Scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,7 @@ Until Corona IDE reaches general availability with required features, it will be
 It is also recommended to turn on "save actions", under the Java Editor settings, to format saved lines and perform other cleanup operations
 
 Once settings are configured, use the Eclipse Gradle IDE plug-in (we are currently using STS) to import all projects from the root of the repository
+
+#### Gradle Build Scan
+
+Corona IDE has the plug-ins required for [Gradle Build Scan](https://gradle.com/) setup. Simply run a build with the `-Dscan` option, and a build scan will be performed

--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,6 @@ sonarqube {
 buildScan {
     licenseAgreementUrl = 'https://gradle.com/terms-of-service'
     licenseAgree = 'yes'
-    
-    publishAlways()
 }
 
 if (project.hasProperty('sonarLogin')) {

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,8 @@ buildscript {
 }
 
 plugins {
-  id 'org.sonarqube' version '2.2'
+    id 'com.gradle.build-scan' version '1.4'
+    id 'org.sonarqube' version '2.2'
 }
 
 sonarqube {
@@ -22,6 +23,13 @@ sonarqube {
         property 'sonar.jacoco.reportPath', "${buildDir}/jacoco/test.exec"
         property 'sonar.host.url', 'https://sonarqube.com'
     }
+}
+
+buildScan {
+    licenseAgreementUrl = 'https://gradle.com/terms-of-service'
+    licenseAgree = 'yes'
+    
+    publishAlways()
 }
 
 if (project.hasProperty('sonarLogin')) {


### PR DESCRIPTION
Add necessary plug-in setup to perform and upload a Gradle Build Scan to Gradle Cloud Services. Must be done manually with a -D switch, as the upload is per-run and at a random address - the results are not kept/linkable at a constant location