### PR TITLE
Remove migrate - Unnecessary complexity without current known use cases

### DIFF
--- a/corona-ide-core-api/src/main/java/com/coronaide/core/datastore/Datastore.java
+++ b/corona-ide-core-api/src/main/java/com/coronaide/core/datastore/Datastore.java
@@ -14,8 +14,6 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
 
-import com.coronaide.core.model.Version;
-
 /**
  * Represents operations used to load/store persistent data for use within Corona IDE
  *
@@ -58,17 +56,4 @@ public interface Datastore<T> {
      */
     T load(BufferedReader source) throws IOException;
 
-    /**
-     * Reads from an input stream, migrating the data from a previous version to the current representation
-     *
-     * @param source
-     *            Reader containing data in a previous version format
-     * @param sourceVersion
-     *            The version the read data is from
-     * @return A migrated representation of the provided data
-     * @throws IOException
-     *             If there is an error reading data during de-serialization
-     * @since 0.1
-     */
-    T migrate(BufferedReader source, Version sourceVersion) throws IOException;
 }

--- a/corona-ide-core-api/src/main/java/com/coronaide/core/datastore/JsonDatastore.java
+++ b/corona-ide-core-api/src/main/java/com/coronaide/core/datastore/JsonDatastore.java
@@ -15,7 +15,6 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.util.Objects;
 
-import com.coronaide.core.model.Version;
 import com.google.gson.Gson;
 
 /**
@@ -70,14 +69,6 @@ public class JsonDatastore<T> implements Datastore<T> {
         Objects.requireNonNull(source);
 
         return gson.fromJson(source, representation);
-    }
-
-    @Override
-    public T migrate(BufferedReader source, Version sourceVersion) throws IOException {
-        Objects.requireNonNull(source);
-        Objects.requireNonNull(sourceVersion);
-
-        return load(source);
     }
 
 }

--- a/corona-ide-core-api/src/test-support/java/com/coronaide/testsupport/core/datastore/TestDatastore.java
+++ b/corona-ide-core-api/src/test-support/java/com/coronaide/testsupport/core/datastore/TestDatastore.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.coronaide.core.datastore.Datastore;
-import com.coronaide.core.model.Version;
 
 /**
  * Simple datastore implementation which allows testing for data storage APIs
@@ -26,8 +25,6 @@ import com.coronaide.core.model.Version;
  * @author romeara
  */
 public class TestDatastore implements Datastore<String> {
-
-    private boolean migrateCalled = false;
 
     @Override
     public String getKey() {
@@ -50,19 +47,6 @@ public class TestDatastore implements Datastore<String> {
         }
 
         return lines.stream().collect(Collectors.joining("\n"));
-    }
-
-    @Override
-    public String migrate(BufferedReader source, Version sourceVersion) throws IOException {
-        migrateCalled = true;
-        return load(source);
-    }
-
-    /**
-     * @return True if the migrate method has been called, false otherwise
-     */
-    public boolean isMigrateCalled() {
-        return migrateCalled;
     }
 
 }

--- a/corona-ide-core-api/src/test/java/com/coronaide/test/core/datastore/JsonDatastoreTest.java
+++ b/corona-ide-core-api/src/test/java/com/coronaide/test/core/datastore/JsonDatastoreTest.java
@@ -23,7 +23,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.coronaide.core.datastore.JsonDatastore;
-import com.coronaide.core.model.Version;
 
 public class JsonDatastoreTest {
 
@@ -121,33 +120,6 @@ public class JsonDatastoreTest {
 
         try (BufferedReader reader = new BufferedReader(new FileReader(testSource))) {
             String result = datastore.load(reader);
-
-            Assert.assertEquals(result, TEST_CONTENT);
-        }
-    }
-
-    @Test(expectedExceptions = NullPointerException.class)
-    public void migrateNullSource() throws Exception {
-        JsonDatastore<String> datastore = new JsonDatastore<>("key", String.class);
-
-        datastore.migrate(null, new Version(0, 0, 1));
-    }
-
-    @Test(expectedExceptions = NullPointerException.class)
-    public void migrateNullSourceVersion() throws Exception {
-        JsonDatastore<String> datastore = new JsonDatastore<>("key", String.class);
-
-        try (BufferedReader reader = new BufferedReader(new FileReader(testSource))) {
-            datastore.migrate(reader, null);
-        }
-    }
-
-    @Test
-    public void migrate() throws Exception {
-        JsonDatastore<String> datastore = new JsonDatastore<>("key", String.class);
-
-        try (BufferedReader reader = new BufferedReader(new FileReader(testSource))) {
-            String result = datastore.migrate(reader, new Version(0, 0, 1));
 
             Assert.assertEquals(result, TEST_CONTENT);
         }

--- a/corona-ide-core/src/main/java/com/coronaide/core/service/impl/DatastoreService.java
+++ b/corona-ide-core/src/main/java/com/coronaide/core/service/impl/DatastoreService.java
@@ -167,12 +167,7 @@ public class DatastoreService implements IDatastoreService {
 
         if (existingVersion.isPresent() && datastoreFile.exists()) {
             try (BufferedReader input = new BufferedReader(new FileReader(datastoreFile))) {
-                if (!Objects.equals(existingVersion.get(), module.getVersion())) {
-                    // Migrate the old data - store must wait until reader is closed
-                    result = datastore.migrate(input, existingVersion.get());
-                } else {
-                    result = datastore.load(input);
-                }
+                result = datastore.load(input);
             }
 
             if (!Objects.equals(existingVersion.get(), module.getVersion())) {

--- a/corona-ide-core/src/test/java/com/coronaide/test/core/service/impl/DatastoreServiceTest.java
+++ b/corona-ide-core/src/test/java/com/coronaide/test/core/service/impl/DatastoreServiceTest.java
@@ -106,19 +106,6 @@ public class DatastoreServiceTest {
     }
 
     @Test
-    public void loadApplicationDataMigrate() throws Exception {
-        // Create a fake corona directory
-        TestDatastore datastore = new TestDatastore();
-
-        Mockito.when(module.getVersion()).thenReturn(new Version(0, 0, 1));
-        datastoreService.store(application, module, datastore, "string");
-
-        Mockito.when(module.getVersion()).thenReturn(new Version(0, 0, 2));
-        Assert.assertEquals(datastoreService.load(application, module, datastore).orElse(null), "string");
-        Assert.assertTrue(datastore.isMigrateCalled());
-    }
-
-    @Test
     public void clearApplicationData() throws Exception {
         // Create a fake corona directory
         TestDatastore datastore = new TestDatastore();
@@ -164,19 +151,6 @@ public class DatastoreServiceTest {
         datastoreService.store(workspace, module, datastore, "string");
 
         Assert.assertEquals(datastoreService.load(workspace, module, datastore).orElse(null), "string");
-    }
-
-    @Test
-    public void loadWorkspaceDataMigrate() throws Exception {
-        // Create a fake corona directory
-        TestDatastore datastore = new TestDatastore();
-
-        Mockito.when(module.getVersion()).thenReturn(new Version(0, 0, 1));
-        datastoreService.store(workspace, module, datastore, "string");
-
-        Mockito.when(module.getVersion()).thenReturn(new Version(0, 0, 2));
-        Assert.assertEquals(datastoreService.load(workspace, module, datastore).orElse(null), "string");
-        Assert.assertTrue(datastore.isMigrateCalled());
     }
 
     @Test


### PR DESCRIPTION
Datastore.migrate() was added originally to cover a possible data-migration use case. However, this case can be addressed in other ways, and the inclusion of this method without strong supporting use-cases at this time is introducing unjustified overhead